### PR TITLE
[FIX] missing flag

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -115,6 +115,7 @@ class Shard extends EventEmitter {
         .fork(path.resolve(this.manager.file), this.args, {
           env: this.env,
           execArgv: this.execArgv,
+          silent: true,
         })
         .on('message', this._handleMessage.bind(this))
         .on('exit', this._exitListener);


### PR DESCRIPTION
with this change it is possible to process' stdin/stdout/stderr when using sharding.
currently we can't listen to those streams, because node regresses those.
see [node documentation](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options)

**Status**

- [✅] Code changes have been tested against the Discord API, or there are no code changes
- [✅] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [❎] This PR changes the library's interface (methods or parameters added)
  - [❎] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [❎] This PR **only** includes non-code changes, like changes to documentation, README, etc.
